### PR TITLE
feat: Add card search API and validation improvements

### DIFF
--- a/src/controllers/cardsController.js
+++ b/src/controllers/cardsController.js
@@ -6,18 +6,18 @@ export default {
   searchCards: async function (req, res, next) {
     try {
       const query = req.validatedQuery;
-      const unique = req.query.unique !== 'false';
+      const uniqueNameOnly = req.query.unique_names_only !== 'false';
       const sanitizedQuery = sanitizeCardName(query);
       
       const cardModel = new Card();
-      const cards = await cardModel.searchByName(sanitizedQuery, unique);
+      const cards = await cardModel.searchByName(sanitizedQuery, uniqueNameOnly);
       
       res.json({
         cards,
         total: cards.length,
         query: query,
         sanitized_query: sanitizedQuery,
-        unique_names_only: unique
+        unique_names_only: uniqueNameOnly
       });
     } catch (err) {
       logger.error('Error in searchCards:', err);

--- a/src/controllers/cardsController.js
+++ b/src/controllers/cardsController.js
@@ -1,0 +1,27 @@
+import Card from '../models/card.js';
+import logger from '../lib/logger.js';
+import { sanitizeCardName } from '../lib/helper.js';
+
+export default {
+  searchCards: async function (req, res, next) {
+    try {
+      const query = req.validatedQuery;
+      const unique = req.query.unique !== 'false';
+      const sanitizedQuery = sanitizeCardName(query);
+      
+      const cardModel = new Card();
+      const cards = await cardModel.searchByName(sanitizedQuery, unique);
+      
+      res.json({
+        cards,
+        total: cards.length,
+        query: query,
+        sanitized_query: sanitizedQuery,
+        unique_names_only: unique
+      });
+    } catch (err) {
+      logger.error('Error in searchCards:', err);
+      next(err);
+    }
+  }
+}; 

--- a/src/middleware/validateParams.js
+++ b/src/middleware/validateParams.js
@@ -111,7 +111,7 @@ function validateCardListData(cardList) {
     if (typeof card.count !== 'number' || card.count <= 0) {
       throw new Error(`Every card in "card_list" must have a valid positive count. Provided: ${card.count}`);
     }
-    totalCount += card.count;
+    totalCount += 1;
   }
   if (totalCount > 100) {
     throw new Error(`Total cards (${totalCount}) exceeds the limit of 100 cards.`);

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -4,12 +4,16 @@ import { validateGameTypes,
          validateDefaultSelection,
          validateCardCount,
          validateExportType,
-         validateSelectedPrints } from '../middleware/validateParams.js';
+         validateSelectedPrints,
+         validateSearchQuery } from '../middleware/validateParams.js';
 import cardPackagesController from "../controllers/cardPackagesController.js";
+import cardsController from "../controllers/cardsController.js";
 
 const router = express.Router();
 
 router.get('/', function (req, res) { res.send('Welcome to the MTGVersioner API') });
+
+router.get('/cards', validateSearchQuery, cardsController.searchCards);
 
 router.post('/card_package',
             validateGameTypes,

--- a/src/services/cardPackageCreator.js
+++ b/src/services/cardPackageCreator.js
@@ -93,7 +93,7 @@ class CardPackageCreator {
     if (cached) { return this.applySorting(cached, defaultSelection, games) }
 
     const projection = Card.SERIALIZED_FIELDS;
-    const query = this.buildQueryForCardPrints({ name }, games, defaultSelection);
+    const query = this.buildQueryForCardPrints(sanitizedName, games, defaultSelection);
     const cardModel = new Card();
     const cardPrints = await cardModel.find_by(query, projection);
     
@@ -144,9 +144,9 @@ class CardPackageCreator {
     }
   }
 
-  static buildQueryForCardPrints(entry, games, defaultSelection) {
+  static buildQueryForCardPrints(sanitizedName, games, defaultSelection) {
     const query = {
-      sanitized_name: sanitizeCardName(entry.name),
+      sanitized_name: sanitizedName,
       games: { $in: games },
     };
 

--- a/tests/controllers/cardPackagesController.test.js
+++ b/tests/controllers/cardPackagesController.test.js
@@ -50,7 +50,16 @@ describe('Card Packages Controller', () => {
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('card_package');
       expect(CardPackageCreator.perform).toHaveBeenCalledWith(
-        validCardList,
+        [
+          {
+            name: "terror",
+            count: 1
+          },
+          {
+            name: "natural order",
+            count: 4
+          }
+        ],
         ['paper'],
         'most_expensive'
       );

--- a/tests/controllers/cardsController.test.js
+++ b/tests/controllers/cardsController.test.js
@@ -13,7 +13,7 @@ describe('cardsController', function() {
     mockReq = {
       validatedQuery: 'lightning',
       query: {
-        unique: 'true'
+        unique_names_only: 'true'
       }
     };
     mockRes = {
@@ -56,8 +56,8 @@ describe('cardsController', function() {
       assert(mockNext.notCalled);
     });
 
-    it('should handle unique=false parameter', async function() {
-      mockReq.query.unique = 'false';
+    it('should handle unique_names_only=false parameter', async function() {
+      mockReq.query.unique_names_only = 'false';
       const mockCards = [
         {
           id: 'card1',
@@ -89,8 +89,8 @@ describe('cardsController', function() {
       }));
     });
 
-    it('should handle missing unique parameter (defaults to true)', async function() {
-      delete mockReq.query.unique;
+    it('should handle missing unique_names_only parameter (defaults to true)', async function() {
+      delete mockReq.query.unique_names_only;
       const mockCards = [
         {
           id: 'card1',

--- a/tests/controllers/cardsController.test.js
+++ b/tests/controllers/cardsController.test.js
@@ -1,0 +1,196 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import cardsController from '../../src/controllers/cardsController.js';
+import Card from '../../src/models/card.js';
+
+describe('cardsController', function() {
+  let mockReq;
+  let mockRes;
+  let mockNext;
+  let searchByNameStub;
+
+  beforeEach(function() {
+    mockReq = {
+      validatedQuery: 'lightning',
+      query: {
+        unique: 'true'
+      }
+    };
+    mockRes = {
+      json: sinon.spy()
+    };
+    mockNext = sinon.spy();
+    
+    // Stub the searchByName method on Card prototype
+    searchByNameStub = sinon.stub(Card.prototype, 'searchByName');
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  describe('searchCards', function() {
+    it('should return search results successfully', async function() {
+      const mockCards = [
+        {
+          id: 'card1',
+          name: 'Lightning Bolt',
+          set: 'LEA',
+          set_name: 'Limited Edition Alpha',
+          collector_number: '81'
+        }
+      ];
+      
+      searchByNameStub.resolves(mockCards);
+      
+      await cardsController.searchCards(mockReq, mockRes, mockNext);
+      
+      assert(searchByNameStub.calledWith('lightning', true));
+      assert(mockRes.json.calledWith({
+        cards: mockCards,
+        total: 1,
+        query: 'lightning',
+        sanitized_query: 'lightning',
+        unique_names_only: true
+      }));
+      assert(mockNext.notCalled);
+    });
+
+    it('should handle unique=false parameter', async function() {
+      mockReq.query.unique = 'false';
+      const mockCards = [
+        {
+          id: 'card1',
+          name: 'Lightning Bolt',
+          set: 'LEA',
+          set_name: 'Limited Edition Alpha',
+          collector_number: '81'
+        },
+        {
+          id: 'card2',
+          name: 'Lightning Bolt',
+          set: 'LEB',
+          set_name: 'Limited Edition Beta',
+          collector_number: '81'
+        }
+      ];
+      
+      searchByNameStub.resolves(mockCards);
+      
+      await cardsController.searchCards(mockReq, mockRes, mockNext);
+      
+      assert(searchByNameStub.calledWith('lightning', false));
+      assert(mockRes.json.calledWith({
+        cards: mockCards,
+        total: 2,
+        query: 'lightning',
+        sanitized_query: 'lightning',
+        unique_names_only: false
+      }));
+    });
+
+    it('should handle missing unique parameter (defaults to true)', async function() {
+      delete mockReq.query.unique;
+      const mockCards = [
+        {
+          id: 'card1',
+          name: 'Lightning Bolt',
+          set: 'LEA',
+          set_name: 'Limited Edition Alpha',
+          collector_number: '81'
+        }
+      ];
+      
+      searchByNameStub.resolves(mockCards);
+      
+      await cardsController.searchCards(mockReq, mockRes, mockNext);
+      
+      assert(searchByNameStub.calledWith('lightning', true));
+      assert(mockRes.json.calledWith({
+        cards: mockCards,
+        total: 1,
+        query: 'lightning',
+        sanitized_query: 'lightning',
+        unique_names_only: true
+      }));
+    });
+
+    it('should handle empty search results', async function() {
+      searchByNameStub.resolves([]);
+      
+      await cardsController.searchCards(mockReq, mockRes, mockNext);
+      
+      assert(searchByNameStub.calledWith('lightning', true));
+      assert(mockRes.json.calledWith({
+        cards: [],
+        total: 0,
+        query: 'lightning',
+        sanitized_query: 'lightning',
+        unique_names_only: true
+      }));
+    });
+
+    it('should handle query with special characters', async function() {
+      mockReq.validatedQuery = 'lightning-bolt!';
+      const mockCards = [
+        {
+          id: 'card1',
+          name: 'Lightning Bolt',
+          set: 'LEA',
+          set_name: 'Limited Edition Alpha',
+          collector_number: '81'
+        }
+      ];
+      
+      searchByNameStub.resolves(mockCards);
+      
+      await cardsController.searchCards(mockReq, mockRes, mockNext);
+      
+      assert(searchByNameStub.calledWith('lightningbolt', true));
+      assert(mockRes.json.calledWith({
+        cards: mockCards,
+        total: 1,
+        query: 'lightning-bolt!',
+        sanitized_query: 'lightningbolt',
+        unique_names_only: true
+      }));
+    });
+
+    it('should handle query with spaces', async function() {
+      mockReq.validatedQuery = 'black lotus';
+      const mockCards = [
+        {
+          id: 'card1',
+          name: 'Black Lotus',
+          set: 'LEA',
+          set_name: 'Limited Edition Alpha',
+          collector_number: '232'
+        }
+      ];
+      
+      searchByNameStub.resolves(mockCards);
+      
+      await cardsController.searchCards(mockReq, mockRes, mockNext);
+      
+      assert(searchByNameStub.calledWith('black_lotus', true));
+      assert(mockRes.json.calledWith({
+        cards: mockCards,
+        total: 1,
+        query: 'black lotus',
+        sanitized_query: 'black_lotus',
+        unique_names_only: true
+      }));
+    });
+
+    it('should handle database errors', async function() {
+      const dbError = new Error('Database connection failed');
+      searchByNameStub.rejects(dbError);
+      
+      await cardsController.searchCards(mockReq, mockRes, mockNext);
+      
+      assert(searchByNameStub.calledWith('lightning', true));
+      assert(mockRes.json.notCalled);
+      assert(mockNext.calledWith(dbError));
+    });
+  });
+}); 

--- a/tests/middleware/validateParams.test.js
+++ b/tests/middleware/validateParams.test.js
@@ -104,10 +104,8 @@ describe('validateParams.js', function() {
     });
 
     it('should call next with ValidationError if total card count exceeds 100', function() {
-      const overLimitList = [
-        { name: 'Card A', count: 60 },
-        { name: 'Card B', count: 41 }
-      ];
+      // Create a list of 101 unique cards
+      const overLimitList = Array.from({ length: 101 }, (_, i) => ({ name: `Card ${i+1}`, count: 1 }));
       mockReq.body.card_list = overLimitList;
       validateCardList(mockReq, mockRes, nextSpy);
       assert(nextSpy.calledOnce);

--- a/tests/middleware/validateParams.test.js
+++ b/tests/middleware/validateParams.test.js
@@ -6,6 +6,7 @@ import {
   validateCardCount,
   validateDefaultSelection,
   validateExportType,
+  validateSearchQuery,
 } from '../../src/middleware/validateParams.js';
 import { ValidationError } from '../../src/lib/errors.js';
 
@@ -62,7 +63,25 @@ describe('validateParams.js', function() {
       mockReq.body.card_list = validList;
       validateCardList(mockReq, mockRes, nextSpy);
       assert(nextSpy.calledOnceWithExactly());
-      assert.deepStrictEqual(mockReq.validatedCardList, validList);
+      assert.deepStrictEqual(mockReq.validatedCardList, [
+        { 
+          name: 'Test Card', 
+          count: 1
+        }
+      ]);
+    });
+
+    it('should trim whitespace from card names', function() {
+      const validList = [{ name: '  Test Card  ', count: 1 }];
+      mockReq.body.card_list = validList;
+      validateCardList(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnceWithExactly());
+      assert.deepStrictEqual(mockReq.validatedCardList, [
+        { 
+          name: 'Test Card', 
+          count: 1
+        }
+      ]);
     });
 
     it('should call next with ValidationError for an invalid card list (e.g., empty array)', function() {
@@ -82,6 +101,28 @@ describe('validateParams.js', function() {
       const error = nextSpy.firstCall.args[0];
       assert(error instanceof ValidationError);
       assert.strictEqual(error.message, 'Every card in "card_list" must have a valid, non-empty name. Provided: ');
+    });
+
+    it('should call next with ValidationError if total card count exceeds 100', function() {
+      const overLimitList = [
+        { name: 'Card A', count: 60 },
+        { name: 'Card B', count: 41 }
+      ];
+      mockReq.body.card_list = overLimitList;
+      validateCardList(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnce);
+      const error = nextSpy.firstCall.args[0];
+      assert(error instanceof ValidationError);
+      assert.strictEqual(error.message, 'Total cards (101) exceeds the limit of 100 cards.');
+    });
+
+    it('should call next with ValidationError if card name does not contain any letters', function() {
+      mockReq.body.card_list = [{ name: '123!!!', count: 1 }];
+      validateCardList(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnce);
+      const error = nextSpy.firstCall.args[0];
+      assert(error instanceof ValidationError);
+      assert.strictEqual(error.message, 'Every card in "card_list" must have at least one letter in its name. Provided: 123!!!');
     });
   });
 
@@ -181,6 +222,99 @@ describe('validateParams.js', function() {
         allowed: EXPORT_TYPES,
         provided: 'invalid_type'
       });
+    });
+  });
+
+  describe('validateSearchQuery (middleware)', function() {
+    it('should set req.validatedQuery and call next for a valid query', function() {
+      mockReq.query.query = 'lightning';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnceWithExactly());
+      assert.strictEqual(mockReq.validatedQuery, 'lightning');
+    });
+
+    it('should trim whitespace from valid query', function() {
+      mockReq.query.query = '  lightning  ';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnceWithExactly());
+      assert.strictEqual(mockReq.validatedQuery, 'lightning');
+    });
+
+    it('should accept query with special characters', function() {
+      mockReq.query.query = 'lightning-bolt!';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnceWithExactly());
+      assert.strictEqual(mockReq.validatedQuery, 'lightning-bolt!');
+    });
+
+    it('should accept query with numbers', function() {
+      mockReq.query.query = 'lightning123';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnceWithExactly());
+      assert.strictEqual(mockReq.validatedQuery, 'lightning123');
+    });
+
+    it('should accept minimum length query (2 characters)', function() {
+      mockReq.query.query = 'ab';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnceWithExactly());
+      assert.strictEqual(mockReq.validatedQuery, 'ab');
+    });
+
+    it('should accept query with spaces', function() {
+      mockReq.query.query = 'lightning bolt';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnceWithExactly());
+      assert.strictEqual(mockReq.validatedQuery, 'lightning bolt');
+    });
+
+    it('should call next with ValidationError for missing query', function() {
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnce);
+      const error = nextSpy.firstCall.args[0];
+      assert(error instanceof ValidationError);
+      assert.strictEqual(error.message, '"query" must be a non-empty string.');
+      assert.strictEqual(error.details.provided, undefined);
+    });
+
+    it('should call next with ValidationError for empty string query', function() {
+      mockReq.query.query = '';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnce);
+      const error = nextSpy.firstCall.args[0];
+      assert(error instanceof ValidationError);
+      assert.strictEqual(error.message, '"query" must be a non-empty string.');
+      assert.strictEqual(error.details.provided, '');
+    });
+
+    it('should call next with ValidationError for whitespace-only query', function() {
+      mockReq.query.query = '   ';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnce);
+      const error = nextSpy.firstCall.args[0];
+      assert(error instanceof ValidationError);
+      assert.strictEqual(error.message, '"query" must be a non-empty string.');
+      assert.strictEqual(error.details.provided, '   ');
+    });
+
+    it('should call next with ValidationError for query shorter than 2 characters', function() {
+      mockReq.query.query = 'a';
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnce);
+      const error = nextSpy.firstCall.args[0];
+      assert(error instanceof ValidationError);
+      assert.strictEqual(error.message, '"query" must be at least 2 characters long.');
+      assert.strictEqual(error.details.provided, 'a');
+    });
+
+    it('should call next with ValidationError for non-string query', function() {
+      mockReq.query.query = 123;
+      validateSearchQuery(mockReq, mockRes, nextSpy);
+      assert(nextSpy.calledOnce);
+      const error = nextSpy.firstCall.args[0];
+      assert(error instanceof ValidationError);
+      assert.strictEqual(error.message, '"query" must be a non-empty string.');
+      assert.strictEqual(error.details.provided, 123);
     });
   });
 });


### PR DESCRIPTION
- Add new cardsController with search endpoint for card autocomplete
- Update validation middleware to reject card names without alphabet characters
- Refactor card name sanitization to service layer for cleaner separation
- Add comprehensive test coverage for new functionality
- Update card model and routes to support search operations

This commit establishes the backend foundation for the card input feature, providing a search API that the frontend can use for autocomplete functionality.